### PR TITLE
fix: dropdown layout width glitch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn(
-          "min-h-screen max-w-7xl mx-auto bg-background font-sans antialiased",
+          "min-h-screen bg-background font-sans antialiased flex justify-center",
           fontSans.variable,
           inter.className
         )}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import { FaGithub, FaLinkedin } from "react-icons/fa";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col gap-8 lg:gap-14 px-4 md:px-20 lg:px-36 py-5 lg:py-20 relative overflow-hidden">
+    <main className="flex min-h-screen max-w-7xl flex-col gap-8 lg:gap-14 px-4 md:px-20 lg:px-36 py-5 lg:py-20 relative overflow-hidden">
       <ScrollProgress />
       <div className="flex flex-col-reverse lg:flex-row  justify-between items-center gap-5">
         {/* Home Title */}

--- a/components/form-fields.tsx
+++ b/components/form-fields.tsx
@@ -90,7 +90,7 @@ export function FormFields() {
   };
 
   return (
-    <div className="grid grid-cols-1 gap-4 p-4 bg-muted/30 rounded-lg border max-w-3xl">
+    <div className="grid grid-cols-1 gap-4 p-4 bg-muted/30 rounded-lg border">
       <div className="mb-2">
         <button
           type="button"


### PR DESCRIPTION
## Fixes
- Fixed graphical bug on bigger screen sizes when opening up `react-select` dropdown. Using `flex justify-center` in `<body>` instead of `mx-auto` fixes the issue
- Removed `max-w-3xl` in `form-fields.tsx` for better symmetry

## Video Evidence
[dropdown-bug.webm](https://github.com/user-attachments/assets/d2b2fc63-b28f-4dea-9633-c9c71b36ebae)